### PR TITLE
Fix TypeScript Error in window.prompt Call in Codeblock Component

### DIFF
--- a/components/ui/codeblock.tsx
+++ b/components/ui/codeblock.tsx
@@ -57,7 +57,7 @@ const CodeBlock: FC<Props> = memo(({ language, value }) => {
     }
     const fileExtension = programmingLanguages[language] || '.file'
     const suggestedFileName = `file-${generateId()}${fileExtension}`
-    const fileName = window.prompt('Enter file name' || '', suggestedFileName)
+    const fileName = window.prompt('Enter file name', suggestedFileName)
 
     if (!fileName) {
       // User pressed cancel on prompt.


### PR DESCRIPTION
Resolved a TypeScript error in the Codeblock component by removing a redundant || expression in the window.prompt